### PR TITLE
Correct clojars dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Onyx plugin providing consumer and producer facilities for kinesis.
 In your project file:
 
 ```clojure
-[org.onyxplatform/onyx-kinesis "0.12.0.0"]
+[org.onyxplatform/onyx-amazon-kinesis "0.11.1.0"]
 ```
 
 In your peer boot-up namespace:


### PR DESCRIPTION
Last stable version on clojars is 0.11.1.0