### PR TITLE
Implement configurable backoff time for reader

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ Lifecycle entry:
 |`:kinesis/endpoint-url`              | `string`  |         | Optional: The Kinesis endpoint-url to connect to.
 |`:kinesis/access-key`                | `string`  |         | Optional: AWS access key to authorize when not using default provider chain. Avoid using kinesis/access-key if possible, as the key will be stored in ZooKeeper.
 |`:kinesis/secret-key`                | `string`  |         | Optional: AWS access key to authorize when not using default provider chain. Avoid using kinesis/access-key if possible, as the key will be stored in ZooKeeper.
+|`:kinesis/reader-backoff-ms`         | `integer`  |         | Optional: Time to backoff a shard reader upon a ProvisionedThroughputExceededException
 
 ##### write-messages
 

--- a/src/onyx/tasks/kinesis.clj
+++ b/src/onyx/tasks/kinesis.clj
@@ -30,6 +30,7 @@
    (s/optional-key :kinesis/secret-key) s/Str
    (s/optional-key :kinesis/endpoint-url) s/Str
    (s/optional-key :kinesis/shard) (s/cond-pre s/Int s/Str)
+   (s/optional-key :kinesis/reader-backoff-ms) s/Int
    (os/restricted-ns :kinesis) s/Any})
 
 (s/defn ^:always-validate consumer


### PR DESCRIPTION
Hello again!

This adds a key :kinesis/reader-backoff-ms to the Kinesis input task which will sleep a shard reader for the specified amount of time upon a ProvisionedThroughputExceededException. If this configuration is not set, the default behavior is unchanged (the exception is not caught and the task may be killed).