### PR TITLE
Stability improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Catalog entry:
  :kinesis/stream-name "mystreamname"
  :kinesis/shard-initialize-type :trim-horizon
  :kinesis/deserializer-fn :my.ns/deserializer-fn
+ :kinesis/poll-interval-ms 250
  :onyx/batch-timeout 50
  :onyx/n-peers << NUMBER OF SHARDS TO READ PARTITIONS, UP TO N-SHARDS MAX >>
  :onyx/batch-size 100
@@ -77,6 +78,7 @@ Lifecycle entry:
 |`:kinesis/access-key`                | `string`  |         | Optional: AWS access key to authorize when not using default provider chain. Avoid using kinesis/access-key if possible, as the key will be stored in ZooKeeper.
 |`:kinesis/secret-key`                | `string`  |         | Optional: AWS access key to authorize when not using default provider chain. Avoid using kinesis/access-key if possible, as the key will be stored in ZooKeeper.
 |`:kinesis/reader-backoff-ms`         | `integer`  |         | Optional: Time to backoff a shard reader upon a ProvisionedThroughputExceededException
+|`:kinesis/poll-interval-ms`          | `integer`  |         | Optional: Minimum time in-between getRecords requests. Tune to match your provisioned shard throughput.
 
 ##### write-messages
 

--- a/src/onyx/kinesis/information_model.cljc
+++ b/src/onyx/kinesis/information_model.cljc
@@ -42,7 +42,11 @@
              {:doc "Optional: Time to backoff a shard reader upon a ProvisionedThroughputExceededException"
               :type :integer
               :optional? true}
-             }}
+
+             :kinesis/poll-interval-ms
+             {:doc "Optional: Minimum time in-between getRecords requests. Tune to match your provisioned shard throughput."
+              :type :integer
+              :optional? true}}}
 
     :onyx.plugin.kinesis/write-messages
     {:summary "Write messages to kinesis."

--- a/src/onyx/kinesis/information_model.cljc
+++ b/src/onyx/kinesis/information_model.cljc
@@ -36,7 +36,13 @@
              :kinesis/secret-key
              {:doc "Optional: AWS access key to authorize when not using default provider chain. Avoid using kinesis/access-key if possible, as the key will be stored in ZooKeeper."
               :type :string
-              :optional? true}}}
+              :optional? true}
+
+             :kinesis/reader-backoff-ms
+             {:doc "Optional: Time to backoff a shard reader upon a ProvisionedThroughputExceededException"
+              :type :integer
+              :optional? true}
+             }}
 
     :onyx.plugin.kinesis/write-messages
     {:summary "Write messages to kinesis."

--- a/src/onyx/tasks/kinesis.clj
+++ b/src/onyx/tasks/kinesis.clj
@@ -31,6 +31,7 @@
    (s/optional-key :kinesis/endpoint-url) s/Str
    (s/optional-key :kinesis/shard) (s/cond-pre s/Int s/Str)
    (s/optional-key :kinesis/reader-backoff-ms) s/Int
+   (s/optional-key :kinesis/poll-interval-ms) s/Int
    (os/restricted-ns :kinesis) s/Any})
 
 (s/defn ^:always-validate consumer


### PR DESCRIPTION
- Do not kill the job on transient errors (AWS timeouts etc).
- Respect batch-timeout in our poll! function (unless we are forcing a backoff period)
- Add a configurable poll-interval. The poll! function will return immediately with whatever is in the current buffer unless it's been enough time since the last poll! to do another request. Setting this right should make backoff periods unnecessary - this is a better way to tune jobs.